### PR TITLE
Fix: Remove Unicode Character Causing Issues on Windows

### DIFF
--- a/ghost_xss.py
+++ b/ghost_xss.py
@@ -129,9 +129,9 @@ def main():
         logger.error(f"{RED}❌ Payloads file '{args.payloads}' NOT FOUND.{RESET}")
         sys.exit(1)
 
-    logger.info(f"{CYAN}🔍 [START] Searching for vulnerable parameters: {args.url}...{RESET}")
+    logger.info(f"{CYAN} [START] Searching for vulnerable parameters: {args.url}...{RESET}")
     urls = crawl_website(args.url)
-    logger.info(f"{CYAN}🔍 [INFO] Found {len(urls)} URLs to test.{RESET}")
+    logger.info(f"{CYAN} [INFO] Found {len(urls)} URLs to test.{RESET}")
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
         futures = []


### PR DESCRIPTION
Issue:
The Unicode magnifying glass character 🔍 in 2 logging statements caused issues on Windows, while it worked fine on Linux.
Some Windows terminals do not support this character, leading to display or execution issues.
Fix:
Removed the 🔍 character in these two logging statements:
`
logger.info(f"{CYAN} [START] Searching for vulnerable parameters: {args.url}...{RESET}") 
logger.info(f"{CYAN} [INFO] Found {len(urls)} URLs to test.{RESET}")
`
This ensures compatibility across Windows operating systems aswell.
Testing:
Tested on Windows, and the script now runs without issues.
Confirmed it still works fine on Linux.
Notes:
This fix maintains functionality while ensuring broader compatibility.